### PR TITLE
Correct Free Software Foundation address in COPYING

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -2,7 +2,7 @@
 		       Version 2, June 1991
 
  Copyright (C) 1989, 1991 Free Software Foundation, Inc.
-                          675 Mass Ave, Cambridge, MA 02139, USA
+                          51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
  Everyone is permitted to copy and distribute verbatim copies
  of this license document, but changing it is not allowed.
 


### PR DESCRIPTION
Packaging qm-dsp for Fedora, the review system found that FSF address is the old one.
Our policy is to report that upstream.